### PR TITLE
skip login procedure in FRINX Machine cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,6 +4,7 @@
   "viewportWidth": 1024,
   "env": {
     "inventory": "http://localhost:5601",
+    "SKIP_LOGIN": true,
     "login": "",
     "password": ""
   }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -51,6 +51,7 @@ Cypress.Commands.add("unmount_incompatible_devices", () => {
     cy.contains('netconf-testtool').should('not.to.exist')
 })
 
+if (!Cypress.env("SKIP_LOGIN")) {
 Cypress.Commands.add("login", () => {
     let login = Cypress.env('login')
     let password= Cypress.env('password')
@@ -60,3 +61,8 @@ Cypress.Commands.add("login", () => {
     cy.get('button').contains('Sign In').click()
     cy.contains('Workflows')
 })
+} else {
+Cypress.Commands.add("login", () => {
+;
+})
+}


### PR DESCRIPTION
in FRINX Machine repo was currently removed auth functionality
as a result while using latest docker images no login is required
new variable is used to supress login procedure in test

CYPRESS_baseUrl=http://10.19.0.5:3000 \
CYPRESS_inventory=http://10.19.0.5:5601 \
CYPRESS_SKIP_LOGIN=true \
~/node_modules/.bin/cypress open --browser chrome

Signed-off-by: Stanislav Chlebec <schlebec@frinx.io>