### PR TITLE
fix workflows related to save&execute commands on devices and Build_read_store_LLDP_topology

### DIFF
--- a/workflows/Build_read_store_LLDP_topology.json
+++ b/workflows/Build_read_store_LLDP_topology.json
@@ -1,7 +1,7 @@
 {
-  "updateTime": 1587480728363,
   "name": "Build_read_store_LLDP_topology",
   "description": "Build, read and store LLDP topology in database - DEMO,LLDP",
+  "workflowStatusListenerEnabled": true,
   "version": 1,
   "tasks": [
     {

--- a/workflows/Build_read_store_LLDP_topology.json
+++ b/workflows/Build_read_store_LLDP_topology.json
@@ -1,8 +1,48 @@
 {
+  "updateTime": 1587480728363,
   "name": "Build_read_store_LLDP_topology",
   "description": "Build, read and store LLDP topology in database - DEMO,LLDP",
-  "workflowStatusListenerEnabled": true,
   "version": 1,
+  "tasks": [
+    {
+      "name": "LLDP_build_topology",
+      "taskReferenceName": "LLDP_build_topology",
+      "inputParameters": {
+        "node-aggregation": "${workflow.input.node-aggregation}",
+        "link-aggregation": "${workflow.input.link-aggregation}",
+        "per-node-read-timeout": "${workflow.input.per-node-read-timeout}",
+        "concurrent-read-nodes": "${workflow.input.concurrent-read-nodes}",
+        "destination-topology": "${workflow.input.destination-topology}"
+      },
+      "type": "SIMPLE",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    },
+    {
+      "name": "LLDP_read_topology",
+      "taskReferenceName": "LLDP_read_topology",
+      "inputParameters": {
+        "destination-topology": "${workflow.input.destination-topology}"
+      },
+      "type": "SIMPLE",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    },
+    {
+      "name": "LLDP_store_topology",
+      "taskReferenceName": "LLDP_store_topology",
+      "inputParameters": {
+        "destination-topology": "${workflow.input.destination-topology}",
+        "content": "${LLDP_read_topology.output.response_body.topology}"
+      },
+      "type": "SIMPLE",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    }
+  ],
   "inputParameters": [
     "node-aggregation[Which unique attribute of a device to use in order to identify a device. This reduces node duplicity][system-name]",
     "link-aggregation[Which unique attribute of a link to use in order to identify a device e.g. source and destination interfaces][bidirectional-abbreviations]",
@@ -10,40 +50,11 @@
     "concurrent-read-nodes[How many devices to query in parallel][8]",
     "destination-topology[Name of a topology under which the result will be stored][lldp]"
   ],
-  "tasks": [
-    {
-      "name": "LLDP_build_topology",
-      "taskReferenceName": "LLDP_build_topology",
-      "type": "SIMPLE",
-      "inputParameters": {
-        "node-aggregation": "${workflow.input.node-aggregation}",
-        "link-aggregation": "${workflow.input.link-aggregation}",
-        "per-node-read-timeout": "${workflow.input.per-node-read-timeout}",
-        "concurrent-read-nodes": "${workflow.input.concurrent-read-nodes}",
-        "destination-topology": "${workflow.input.destination-topology}"
-      }
-    },
-    {
-      "name": "LLDP_read_topology",
-      "taskReferenceName": "LLDP_read_topology",
-      "type": "SIMPLE",
-      "inputParameters": {
-        "destination-topology": "${workflow.input.destination-topology}"
-      }
-    },
-    {
-      "name": "LLDP_store_topology",
-      "taskReferenceName": "LLDP_store_topology",
-      "type": "SIMPLE",
-      "inputParameters": {
-        "destination-topology": "${workflow.input.destination-topology}",
-        "content": "${workflow.input.content}"
-      }
-    }
-  ],
   "outputParameters": {
     "destination-topology": "${workflow.input.destination-topology}",
     "content": "${LLDP_read_topology.output.response.topology}"
   },
-  "schemaVersion": 2
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false
 }

--- a/workflows/Execute_all_from_cli_update_inventory.json
+++ b/workflows/Execute_all_from_cli_update_inventory.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "command_id[Unique command identifier]",
+    "template_id[Unique command identifier]",
     "params[]"
   ],
   "tasks": [
@@ -15,7 +15,7 @@
       "inputParameters": {
         "task": "Execute_and_read_rpc_cli_device_from_inventory_update_inventory",
         "task_params": {
-          "command_id": "${workflow.input.command_id}",
+          "template_id": "${workflow.input.template_id}",
           "params": "${workflow.input.params}"
         }
       }

--- a/workflows/Execute_and_read_rpc_cli_device_from_inventory.json
+++ b/workflows/Execute_and_read_rpc_cli_device_from_inventory.json
@@ -29,7 +29,7 @@
     }
   ],
   "outputParameters": {
-    "output": "${execute_template.output.output}"
+    "output": "${execute_template.output.response_body}"
   },
   "schemaVersion": 2
 }

--- a/workflows/Execute_and_read_rpc_cli_device_from_inventory_update_inventory.json
+++ b/workflows/Execute_and_read_rpc_cli_device_from_inventory_update_inventory.json
@@ -29,13 +29,13 @@
       "inputParameters": {
         "device_id": "${workflow.input.device_id}",
         "field": "${workflow.input.template_id}",
-        "value": "${execute_template.output.output}"
+        "value": "${execute_template.output.output.output.output}"
       },
       "type": "SIMPLE"
     }
   ],
   "outputParameters": {
-    "output": "${execute_template.output.output}"
+    "output": "${execute_template.output}"
   },
   "schemaVersion": 2
 }


### PR DESCRIPTION
- fix output to contain the result of command
- unite the input parameter naming (command_id -> template_id)
  to be the same as in SUB WORKFLOWS

Signed-off-by: Stanislav Chlebec <schlebec@frinx.io>