### PR TITLE
Remove 'node_id' input type from workflows

### DIFF
--- a/micros-demo/workflows/Create_L2VPN_P2P_OC_uniconfig.json
+++ b/micros-demo/workflows/Create_L2VPN_P2P_OC_uniconfig.json
@@ -122,7 +122,7 @@
     }
   ],
   "inputParameters": [
-    "{\"node01\":{\"value\":\"IOS01\",\"description\":\"First node of P2P connection\",\"type\":\"node_id\"},\"node02\":{\"value\":\"IOS02\",\"description\":\"Second node of P2P connection\",\"type\":\"node_id\"},\"interface01\":{\"value\":\"GigabitEthernet1\",\"description\":\"Customer facing service interface on first node\",\"type\":\"string\"},\"vcid\":{\"value\":\"444\",\"description\":\"Virtual Circuit Identifier (globally unique)\",\"type\":\"string\"},\"interface02\":{\"value\":\"GigabitEthernet3\",\"description\":\"Customer facing service interface on second node\",\"type\":\"string\"}}"
+    "{\"node01\":{\"value\":\"IOS01\",\"description\":\"First node of P2P connection\",\"type\":\"string\"},\"node02\":{\"value\":\"IOS02\",\"description\":\"Second node of P2P connection\",\"type\":\"string\"},\"interface01\":{\"value\":\"GigabitEthernet1\",\"description\":\"Customer facing service interface on first node\",\"type\":\"string\"},\"vcid\":{\"value\":\"444\",\"description\":\"Virtual Circuit Identifier (globally unique)\",\"type\":\"string\"},\"interface02\":{\"value\":\"GigabitEthernet3\",\"description\":\"Customer facing service interface on second node\",\"type\":\"string\"}}"
   ],
   "outputParameters": {
     "response_body": "Journal for ${workflow.input.node01}:  ${read_journal_cli_device_ref_LJUO.output.journal} --------  Journal for ${workflow.input.node02}:  ${read_journal_cli_device_ref_CDGP.output.journal}"

--- a/micros-demo/workflows/Create_loopback_interface_uniconfig.json
+++ b/micros-demo/workflows/Create_loopback_interface_uniconfig.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"},\"loopback_id\":{\"value\":\"\",\"description\":\"Unique loopback identifier (e.g. 77)\",\"type\":\"string\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"},\"loopback_id\":{\"value\":\"\",\"description\":\"Unique loopback identifier (e.g. 77)\",\"type\":\"string\"}}"
   ],
   "tasks": [
     {

--- a/micros-demo/workflows/Delete_loopback_interface_uniconfig.json
+++ b/micros-demo/workflows/Delete_loopback_interface_uniconfig.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"},\"loopback_id\":{\"value\":\"\",\"description\":\"Unique loopback identifier (e.g. 77)\",\"type\":\"string\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"},\"loopback_id\":{\"value\":\"\",\"description\":\"Unique loopback identifier (e.g. 77)\",\"type\":\"string\"}}"
   ],
   "tasks": [
     {

--- a/micros-demo/workflows/Execute_and_read_rpc_cli_device_from_inventory.json
+++ b/micros-demo/workflows/Execute_and_read_rpc_cli_device_from_inventory.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "{\"template_id\":{\"value\":\"\",\"description\":\"Unique command template identifier\",\"type\":\"string\"},\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"},\"params\":{\"value\":\"\",\"description\":\"\",\"type\":\"string\"}}"
+    "{\"template_id\":{\"value\":\"\",\"description\":\"Unique command template identifier\",\"type\":\"string\"},\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"},\"params\":{\"value\":\"\",\"description\":\"\",\"type\":\"string\"}}"
   ],
   "tasks": [
     {

--- a/micros-demo/workflows/Execute_and_read_rpc_cli_device_from_inventory_update_inventory.json
+++ b/micros-demo/workflows/Execute_and_read_rpc_cli_device_from_inventory_update_inventory.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"},\"template_id\":{\"value\":\"\",\"description\":\"Unique command template identifier\",\"type\":\"string\"},\"params\":{\"value\":\"\",\"description\":\"\",\"type\":\"string\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"},\"template_id\":{\"value\":\"\",\"description\":\"Unique command template identifier\",\"type\":\"string\"},\"params\":{\"value\":\"\",\"description\":\"\",\"type\":\"string\"}}"
   ],
   "tasks": [
     {

--- a/micros-demo/workflows/Link_aggregation.json
+++ b/micros-demo/workflows/Link_aggregation.json
@@ -160,7 +160,7 @@
     }
   ],
   "inputParameters": [
-    "{\"node1\":{\"value\":\"XR01\",\"description\":\"First node to create a link aggregation with\",\"type\":\"node_id\"},\"bundle_ether_id\":{\"value\":\"3\",\"description\":\"BundleEtherX\",\"type\":\"string\"},\"bundle_ether_enabled\":{\"value\":\"true\",\"description\":\"enabled\",\"type\":\"string\"},\"node2\":{\"value\":\"XR02\",\"description\":\"Second node to create a link aggregation with\",\"type\":\"node_id\"},\"node1_ifaces\":{\"value\":\"GigabitEthernet0/0/0/0, GigabitEthernet0/0/0/1\",\"description\":\"Interfaces for node1\",\"type\":\"string\"},\"node2_ifaces\":{\"value\":\"GigabitEthernet0/0/0/1, GigabitEthernet0/0/0/2, GigabitEthernet0/0/0/3\",\"description\":\"Interfaces for node2\",\"type\":\"string\"}}"
+    "{\"node1\":{\"value\":\"XR01\",\"description\":\"First node to create a link aggregation with\",\"type\":\"string\"},\"bundle_ether_id\":{\"value\":\"3\",\"description\":\"BundleEtherX\",\"type\":\"string\"},\"bundle_ether_enabled\":{\"value\":\"true\",\"description\":\"enabled\",\"type\":\"string\"},\"node2\":{\"value\":\"XR02\",\"description\":\"Second node to create a link aggregation with\",\"type\":\"string\"},\"node1_ifaces\":{\"value\":\"GigabitEthernet0/0/0/0, GigabitEthernet0/0/0/1\",\"description\":\"Interfaces for node1\",\"type\":\"string\"},\"node2_ifaces\":{\"value\":\"GigabitEthernet0/0/0/1, GigabitEthernet0/0/0/2, GigabitEthernet0/0/0/3\",\"description\":\"Interfaces for node2\",\"type\":\"string\"}}"
   ],
   "outputParameters": {
     "Aggregation link ID": "${workflow.input.bundle_ether_id}"

--- a/micros-demo/workflows/Read_components_openconfig.json
+++ b/micros-demo/workflows/Read_components_openconfig.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"}}"
   ],
   "tasks": [
     {

--- a/micros-demo/workflows/Read_components_update_inventory.json
+++ b/micros-demo/workflows/Read_components_update_inventory.json
@@ -32,6 +32,6 @@
   },
   "schemaVersion": 2,
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"}}"
   ]
 }

--- a/micros-demo/workflows/Read_journal_cli_device.json
+++ b/micros-demo/workflows/Read_journal_cli_device.json
@@ -16,7 +16,7 @@
     }
   ],
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique identifier of device. Example: IOS01\",\"type\":\"node_id\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique identifier of device. Example: IOS01\",\"type\":\"string\"}}"
   ],
   "outputParameters": {
     "journal": "${CLI_get_cli_journal.output.response_body.output.journal}"

--- a/micros-demo/workflows/Unmount_cli_device.json
+++ b/micros-demo/workflows/Unmount_cli_device.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"}}"
   ],
   "tasks": [
     {

--- a/micros-demo/workflows/Unmount_netconf_device.json
+++ b/micros-demo/workflows/Unmount_netconf_device.json
@@ -4,7 +4,7 @@
   "workflowStatusListenerEnabled": true,
   "version": 1,
   "inputParameters": [
-    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"node_id\"}}"
+    "{\"device_id\":{\"value\":\"\",\"description\":\"Unique device identifier. Example: IOS01\",\"type\":\"string\"}}"
   ],
   "tasks": [
     {


### PR DESCRIPTION
`node_id` type input field was previously dropdown with all available mounted devices, since uniflow-ui is not communicating with uniconfig it is not usable anymore - this also fixes related bug in uniflow-ui.

Signed-off-by: Adam Chmara <adam.chmara1@gmail.com>