### PR TITLE
Change default env for FM uniconfig service

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -49,7 +49,7 @@ function argumentsCheck {
 
 __SCRIPT_NAME="$(basename "${0}")"
 stackName="fm"
-UNICONFIG_SERVICENAME="${HOSTNAME,,}_uniconfig"
+UNICONFIG_SERVICENAME="uniconfig"
 
 
 argumentsCheck "$@"


### PR DESCRIPTION
change of default uniconfig service name to 'uniconfig' based on Frinx Machine
https://github.com/FRINXio/FRINX-machine/blob/master/env.template#L12