### PR TITLE
update netconf testtool version in sample-topology dockerfile

### DIFF
--- a/sample-topology/Dockerfile
+++ b/sample-topology/Dockerfile
@@ -23,4 +23,4 @@ RUN apk add ulogd
 WORKDIR /sample-topology
 COPY ./ ./
 
-ADD  https://license.frinx.io/download/netconf-testtool-1.4.2-Oxygen-SR2.4_2_9_rc1-frinxodl-executable.jar /./netconf-testtool/
+ADD  https://license.frinx.io/download/netconf-testtool-1.4.2-Oxygen-SR2.4_2_10_rc5-frinxodl-SNAPSHOT-executable.jar /./netconf-testtool/


### PR DESCRIPTION
updated netconf testtool can send cache schemas from simulated devices to UC.
Benefit is that user not need manually add schemas to FM cache it will be automatically downloaded from simulated devices during installation