### PR TITLE
Edit jsonJQ filter

### DIFF
--- a/demo-workflows/workflows/Uniconfig_policy_filter_XR.json
+++ b/demo-workflows/workflows/Uniconfig_policy_filter_XR.json
@@ -64,7 +64,7 @@
       "taskReferenceName": "jsonJQ_oOEn",
       "inputParameters": {
         "key": "${UNICONFIG_read_structured_device_dataRefName_8xGO.output.response_body}",
-        "queryExpression": ".key | .[\"frinx-uniconfig-topology:configuration\"][\"Cisco-IOS-XR-ifmgr-cfg:interface-configurations\"] . \"interface-configuration\" | select(. != null) | .[] | select(.description == \"${workflow.input.Description}\") | {interface: .\"interface-name\"}"
+        "queryExpression": ".key | .[\"Cisco-IOS-XR-ifmgr-cfg:interface-configurations\"] . \"interface-configuration\" | select(. != null) | .[] | select(.description == \"${workflow.input.Description}\") | {interface: .\"interface-name\"}"
       },
       "type": "JSON_JQ_TRANSFORM",
       "decisionCases": {},


### PR DESCRIPTION
Changed the input of jsonJQ filter task, so it reads through smaller part of the device configuration. 
This smaller part of the device configuration is parsed by the URI in the input of the workflow and this step has also been added to the documentation of this demo workflow. This is done to prevent the jsonJQ filter task to read data from external storage.