### PR TITLE
Fix Dockerfile for non-root enviroment

### DIFF
--- a/sample-topology/Dockerfile
+++ b/sample-topology/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add gcc musl-dev python-dev libffi-dev openssl-dev cargo
 RUN apk add --no-cache --upgrade bash
 RUN apk add --update openssh
 RUN apk add --update iptables
+RUN apk add --no-cache netcat-openbsd
 RUN apk add openjdk11
 
 # Install dependencies for ncclient
@@ -21,3 +22,4 @@ RUN pip install typing
 RUN pip install --no-cache-dir -r requirements.txt
 
 ADD  https://license.frinx.io/download/netconf-testtool-1.4.2-Oxygen-SR2.4_2_10_rc5-frinxodl-SNAPSHOT-executable.jar /./netconf-testtool/
+RUN chmod +r /./netconf-testtool/netconf-testtool-1.4.2-Oxygen-SR2.4_2_10_rc5-frinxodl-SNAPSHOT-executable.jar


### PR DESCRIPTION
- Added netcat-openbsd for the possibility of a health check
- Added read permission for netconf-testool .jar file