### PR TITLE
Fix over half of critical vulnerabilities

### DIFF
--- a/demo-workflows/Dockerfile
+++ b/demo-workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.10-buster
+FROM python:3.6.15-buster
 
 WORKDIR /home/app
 
@@ -6,7 +6,7 @@ WORKDIR /home/app
 ### Install application setup
 COPY ./requirements.txt ./requirements.txt
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 RUN apt-get update
 RUN apt-get -y install nano
 


### PR DESCRIPTION
Our scanners are red hot from this image with almost 4000 detected vulnerabilities. Upgrading the base image to 3.6.15 would cut over half of the critical ones. Also makes the image a bit smaller.

Numbers from Trivy:
Original: 3967 (UNKNOWN: 15, LOW: 1293, MEDIUM: 1305, HIGH: 1184, CRITICAL: 170)
This PR: 2720 (UNKNOWN: 15, LOW: 1244, MEDIUM: 755, HIGH: 635, CRITICAL: 73)

Image size 914MB -> 871MB

Adding a step for `apt-get upgrade -y` would further cut down vulnerabilities to:
Total: 1970 (UNKNOWN: 0, LOW: 1220, MEDIUM: 448, HIGH: 291, CRITICAL: 13)
